### PR TITLE
fix: lacking rust optimization flag

### DIFF
--- a/rust/rust-script.sh
+++ b/rust/rust-script.sh
@@ -1,5 +1,5 @@
 if [ ! -f src/?akefile ]; then
-    compilation_command="rustc ${src_file} -o ${user_bin}"
+    compilation_command="rustc -O ${src_file} -o ${user_bin}"
     run_command="./${user_bin}"
 fi
 


### PR DESCRIPTION
# Rust Optimization Fix

Introduce rust optimization flag to be consistent with cpp compile script

![Rust Ferris Trans](https://upload.wikimedia.org/wikipedia/commons/b/b7/Ferris_trans_flag_pride.jpg)